### PR TITLE
Ability to override with a local version

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ Just execute:
 $ npm run build
 ```
 
+## Overriding with a local version
+
+Cf. [Overriding published packages with a local version](https://guide.meteor.com/writing-atmosphere-packages.html#overriding-atmosphere-packages)
+
+After copying the `runisland:ionic4` package under the folder `packages` of the Meteor project, add two dedicated scripts to the project file `package.json` :
+
+```
+mkdir -p packages
+cd packages
+git clone https://github.com/runisland/meteor-ionic4.git
+cd ..
+# Here, a section `scripts` is assumed with already at least one script:
+sed -i '/^\s*"scripts"\s*:/ a\
+    "postinstall": "npm run meteor:ionic4",\
+    "meteor:ionic4": "cd packages/meteor-ionic4 && npm run build",
+' package.json
+```
 
 ## License
 

--- a/package.js
+++ b/package.js
@@ -1,5 +1,6 @@
 const path = Npm.require('path');
 const fs = Npm.require('fs');
+const runislandIonic4PackageName = 'runisland-ionic4';
 
 Package.describe({
   name: 'runisland:ionic4',
@@ -15,13 +16,53 @@ Package.onUse((api) => {
   api.addFiles('scriptIonic.html', 'client');
 
   // Within package.js we do not have access to `process` or `__dirname`, so we have to assume the path…
-  const files = getFilesRecursive('./dist');
+  const runislandIonic4PackagePath = isMeteorProject('.') ? getRunislandIonic4Package('.') : '.';
 
-  api.addAssets(files, 'client');
+  const distPath = runislandIonic4PackagePath ? path.join(runislandIonic4PackagePath, 'dist') : null;
+  const files = distPath ? getFilesRecursive(distPath) : null;
+  if (files) {
+    const fileRelPathes = files.map ((p) => {
+      return path.relative(runislandIonic4PackagePath, p);
+    })
+    api.addAssets(fileRelPathes, 'client');
+  } else {
+    console.log("Something went wrong: no 'dist' folder available.");
+  } 
+
 });
 
 // No test, only side effect of adding Ionic4 assets and loading ionic.js script.
 
+
+function isMeteorProject(source) {
+  return getChildren(source).indexOf('.meteor') > -1;
+}
+
+function getRunislandIonic4Package(source) {
+  const packagesPath = path.resolve(source, 'packages');
+  const packagePathes = getChildren(packagesPath);
+  return packagePathes.find((p) => {
+    if (!isDir(p)) {
+      return;
+    }
+
+    const packageJsonPath = path.resolve(p, 'package.json');
+    const result = isRunislandIonic4PackageJson(packageJsonPath);
+    return result;
+  })
+
+}
+
+function isRunislandIonic4PackageJson(source) {
+  if (! isFile(source)) {
+    return false;
+  }
+
+  const content = fs.readFileSync(source, 'utf8');
+  const jsonContent = JSON.parse(content);
+  const packageName = jsonContent.name;
+  return packageName === runislandIonic4PackageName;
+}
 
 function isDir(source) {
   return fs.lstatSync(source).isDirectory();


### PR DESCRIPTION
Allow to work with a copy of the package inside a Meteor project.

See [Overriding published packages with a local version](https://guide.meteor.com/writing-atmosphere-packages.html#overriding-atmosphere-packages)