### PR TITLE
feat(package): sync @ionic/core v5.4.4 + use new ionic entry file

### DIFF
--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "runisland-ionic4",
-  "version": "5.4.1",
+  "version": "5.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -31,9 +31,9 @@
       }
     },
     "@ionic/core": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-5.4.1.tgz",
-      "integrity": "sha512-yONXeHjbVGUSL7zPgiCv0fQkw47VHJJ+8zVkYgTg4At+B0VhoLAMgS/ah3EUwSVTOATXdHa6Ak5+71uHPKpViQ==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-5.4.4.tgz",
+      "integrity": "sha512-MSA3LJJmOR8S8XDTsHCrnq+nCUmuvgZDTZzrrulpPdyTHNbphhJYw991JfTzFKRfQDQKs+6+xJAovLBaiYyszA==",
       "dev": true,
       "requires": {
         "ionicons": "^5.1.2",
@@ -54,6 +54,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+      "dev": true
+    },
+    "@stencil/core": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.8.1.tgz",
+      "integrity": "sha512-iv9J6oLO/lv7/aO45M05yw3pp1J7olY400vlOZgdMVs3s5zHfalY1ZPYM0KyqU4+7DZuadKYbd0aQZ/g2PInZw==",
       "dev": true
     },
     "@types/glob": {
@@ -905,10 +911,13 @@
       "dev": true
     },
     "ionicons": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-5.2.3.tgz",
-      "integrity": "sha512-87qtgBkieKVFagwYA9Cf91B3PCahQbEOMwMt8bSvlQSgflZ4eE5qI4MGj2ZlIyadeX0dgo+0CzZsy3ow0CsBAg==",
-      "dev": true
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-5.5.3.tgz",
+      "integrity": "sha512-L71djrMi8pAad66tpwdnO1vwcyluCFvehzxU1PpH1k/HpYBZhZ5IaYhqXipmqUvu5aEbd4cbRguYyI5Fd4bxTw==",
+      "dev": true,
+      "requires": {
+        "@stencil/core": "^2.5.0"
+      }
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",

--- a/package/package.js
+++ b/package/package.js
@@ -4,7 +4,7 @@ const runislandIonic4PackageName = "runisland-ionic4";
 
 Package.describe({
   name: "runisland:ionic4",
-  version: "5.4.1", // Meteor package wrap number https://docs.meteor.com/api/packagejs.html#PackageNamespace-describe
+  version: "5.4.4", // Meteor package wrap number https://docs.meteor.com/api/packagejs.html#PackageNamespace-describe
   summary:
     "Automatically import Ionic4 Web Components into your Client templates",
   git: "https://github.com/runisland/meteor-ionic4.git",
@@ -16,7 +16,7 @@ Package.onUse((api) => {
   api.addFiles("ionicResourcesUrl.js", "client");
   // We can now bundle the @ionic/core loader with the rest of the Meteor App code.
   // It will read the above hard-coded path instead of guessing it.
-  api.addFiles(path.join("dist", "ionic.js"), "client");
+  api.addFiles(path.join("dist", "ionic", "ionic.js"), "client");
   // Add the Ionic CSS file (introduced in version 4.0.0-alpha.8).
   // Renamed from "ionic.css" to "ionic.bundle.css" in version 4.0.0-beta.6.
   api.addFiles(path.join("css", "ionic.bundle.css"), "client");

--- a/package/package.json
+++ b/package/package.json
@@ -1,15 +1,14 @@
 {
   "name": "runisland-ionic4",
-  "version": "5.4.1",
+  "version": "5.4.4",
   "description": "Meteor Atmosphere package that automatically imports Ionic4 Web Components into your Client templates",
   "main": "package.js",
   "scripts": {
     "build": "npm install && npm run prepare && npm run copy:all && npm run clean",
     "clean": "node rmdir",
-    "copy:all": "npm run copy:css && npm run copy:dist && npm run copy:ionic",
+    "copy:all": "npm run copy:css && npm run copy:dist",
     "copy:css": "cpy css/**/* ../../../ --parents --cwd=./node_modules/@ionic/core",
     "copy:dist": "cpy ionic/**/* ../../../../dist/ --parents --cwd=./node_modules/@ionic/core/dist",
-    "copy:ionic": "cpy node_modules/@ionic/core/dist/ionic.js ./dist/",
     "prepare": "rimraf ./css && rimraf ./dist && mkdirp ./dist"
   },
   "repository": {
@@ -30,7 +29,7 @@
   },
   "homepage": "https://github.com/runisland/ionic4#readme",
   "devDependencies": {
-    "@ionic/core": "5.4.1",
+    "@ionic/core": "5.4.4",
     "cpy-cli": "^3.1.1",
     "mkdirp": "^1.0.4",
     "rimraf": "^2.6.2"


### PR DESCRIPTION
instead of deprecated dist/ionic.js file directly.
Had to skip @ionic/core versions 5.4.2 and 5.4.3
where the new entry file (non esm) was missing,
and introduced back since version 5.4.4.
See https://github.com/runisland/meteor-ionic4/issues/8#issuecomment-778788000
for further details.

Fix #8 